### PR TITLE
Changed Log Level

### DIFF
--- a/filestore/src/main/kotlin/io/guthix/js5/Js5Archive.kt
+++ b/filestore/src/main/kotlin/io/guthix/js5/Js5Archive.kt
@@ -95,7 +95,7 @@ public data class Js5Archive internal constructor(
             groupSettings.fileSettings.size
         )
         val group = Js5Group.create(groupData, groupSettings)
-        logger.info("Reading group ${groupSettings.id} from archive $archiveId")
+        logger.debug("Reading group ${groupSettings.id} from archive $archiveId")
         return group
     }
 


### PR DESCRIPTION
Log level is set to debug instead of info to avoid unnecessary spam  for production environments etc.